### PR TITLE
feat: expose npx command towards the library usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.1 - 2025-4-13
+
+In this PR, I'm enabling the support to call `npx @omariosouto/bumper` to be used in CI always with the latest version available of the bumper bot
+
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Qualistack bumper",
   "main": "index.js",
   "scripts": {
+    "bumper": "node ./index.js",
     "build": "echo 'I need to build the library...'",
     "test": "echo 'There are no tests. But things work trust me!'"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/bumper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Qualistack bumper",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "echo 'I need to build the library...'",
-    "test": "echo 'There are no tests... but things work trust me!'"
+    "test": "echo 'There are no tests. But things work trust me!'"
   },
   "repository": "https://github.com/omariosouto/bumper",
   "publishConfig": {


### PR DESCRIPTION

## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

In this PR, I'm enabling the support to call `npx @omariosouto/bumper` to be used in CI always with the latest version available of the bumper bot
