### PR TITLE
feat: fix repo name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.2.8 - 2025-4-13
+
+This pull request includes changes to the `index.js` file to dynamically fetch the repository name for release comments. This ensures that the release links are always accurate, regardless of the repository they are in.
+Key changes include:
+* Updated the release comment to dynamically fetch the repository name using the new `getRepoName` method. This change is applied to both the regular release and beta release comments. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L77-R77) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L106-R106)
+* Added a new method `getRepoName` to retrieve the repository name dynamically.
+
+
 # 1.1.8 - 2025-4-13
 
 This pull request includes changes to the `index.js` file to dynamically fetch the repository name for release comments. This ensures that the release links are always accurate, regardless of the repository they are in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.1.8 - 2025-4-13
+
+This pull request includes changes to the `index.js` file to dynamically fetch the repository name for release comments. This ensures that the release links are always accurate, regardless of the repository they are in.
+Key changes include:
+* Updated the release comment to dynamically fetch the repository name using the new `getRepoName` method. This change is applied to both the regular release and beta release comments. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L77-R77) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L106-R106)
+* Added a new method `getRepoName` to retrieve the repository name dynamically.
+
+
 # 1.0.8 - 2025-4-13
 
 Making all tests

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@
             await gh.updateCommentOnPR(commentID, (`
 Release created successfully!
             
-- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/${await getRepoName()}/releases/tag/v${PACKAGE_JSON.version})
+- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/${await gh.getRepoName()}/releases/tag/v${PACKAGE_JSON.version})
 - **Version**:
 \`\`\`sh
 ${PACKAGE_JSON.version}
@@ -103,7 +103,7 @@ ${PACKAGE_JSON.version}
         await gh.updateCommentOnPR(commentID, (`
 Beta release created successfully!
       
-- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/${await getRepoName()}/releases/tag/v${PACKAGE_JSON.version})
+- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/${await gh.getRepoName()}/releases/tag/v${PACKAGE_JSON.version})
 - **Version**:
 \`\`\`sh
 ${PACKAGE_JSON.version}

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@
             await gh.updateCommentOnPR(commentID, (`
 Release created successfully!
             
-- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/tsconfig/releases/tag/v${PACKAGE_JSON.version})
+- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/${await getRepoName()}/releases/tag/v${PACKAGE_JSON.version})
 - **Version**:
 \`\`\`sh
 ${PACKAGE_JSON.version}
@@ -103,7 +103,7 @@ ${PACKAGE_JSON.version}
         await gh.updateCommentOnPR(commentID, (`
 Beta release created successfully!
       
-- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/tsconfig/releases/tag/v${PACKAGE_JSON.version})
+- **Package**: [\`${PACKAGE_JSON.name}\`](https://github.com/omariosouto/${await getRepoName()}/releases/tag/v${PACKAGE_JSON.version})
 - **Version**:
 \`\`\`sh
 ${PACKAGE_JSON.version}
@@ -307,6 +307,9 @@ ${PACKAGE_JSON.version}
     console.log("[prInfo]", prInfo);
 
     return {
+      async getRepoName() {
+        return repo;
+      },
       async isPRMergeable() {
         const BASE_URL = `https://api.github.com/repos/${owner}/${repo}/pulls/${PR_NUMBER}`;
         const response = await fetch(BASE_URL, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/bumper",
-  "version": "1.1.8",
+  "version": "1.2.8",
   "bin": {
     "omariosouto-bumper": "./bin/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/bumper",
-  "version": "1.0.8",
+  "version": "1.1.8",
   "bin": {
     "omariosouto-bumper": "./bin/cli.js"
   },


### PR DESCRIPTION
## Changelog

This pull request includes changes to the `index.js` file to dynamically fetch the repository name for release comments. This ensures that the release links are always accurate, regardless of the repository they are in.

Key changes include:

* Updated the release comment to dynamically fetch the repository name using the new `getRepoName` method. This change is applied to both the regular release and beta release comments. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L77-R77) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L106-R106)
* Added a new method `getRepoName` to retrieve the repository name dynamically.
