### PR TITLE
feat: add support to package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.3.1 - 2025-4-13
+
+This pull request includes several changes to the `index.js` file to improve the handling of the `package.json` exports and streamline the commit process during the CI workflow. The most important changes include adding a function to reset the `package.json` exports, adjusting the order of operations to make a single commit, and ensuring the `package.json` exports are synced post-build.
+### Improvements to handling `package.json` exports:
+* Added `PACKAGE_JSON_ORIGINAL_EXPORTS` to store the original exports from `package.json`.
+* Implemented the `resetPkgExports` function to reset the `package.json` exports to their original state.
+* Modified the `syncPackageJSON` function to update the `package.json` exports with the post-build exports.
+### Streamlining commit process:
+* Adjusted the order of operations to include `resetPkgExports`, `createGitCommit`, and `pushToPR` to ensure a single commit is made instead of multiple commits.
+
+
 # 1.3.0 - 2025-4-13
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.3.2 - 2025-4-13
+
+This pull request includes several changes to the `index.js` file to improve the handling of the `package.json` exports and streamline the commit process during the CI workflow. The most important changes include adding a function to reset the `package.json` exports, adjusting the order of operations to make a single commit, and ensuring the `package.json` exports are synced post-build.
+### Improvements to handling `package.json` exports:
+* Added `PACKAGE_JSON_ORIGINAL_EXPORTS` to store the original exports from `package.json`.
+* Implemented the `resetPkgExports` function to reset the `package.json` exports to their original state.
+* Modified the `syncPackageJSON` function to update the `package.json` exports with the post-build exports.
+### Streamlining commit process:
+* Adjusted the order of operations to include `resetPkgExports`, `createGitCommit`, and `pushToPR` to ensure a single commit is made instead of multiple commits.
+
+
 # 1.3.1 - 2025-4-13
 
 This pull request includes several changes to the `index.js` file to improve the handling of the `package.json` exports and streamline the commit process during the CI workflow. The most important changes include adding a function to reset the `package.json` exports, adjusting the order of operations to make a single commit, and ensuring the `package.json` exports are synced post-build.

--- a/index.js
+++ b/index.js
@@ -259,6 +259,13 @@ ${PACKAGE_JSON.version}
 
     function syncPackageJSON() {
       log("🤖 - [syncPackageJSON] Syncing package.json...");
+      const PACKAGE_JSON_POST_BUILD = fs.readFileSync(path.join(PATH_TO_PACKAGE, "package.json"), "utf-8");
+      const PACKAGE_JSON_POST_BUILD_PARSED = JSON.parse(PACKAGE_JSON_POST_BUILD);
+
+      const pkgExports = PACKAGE_JSON_POST_BUILD_PARSED?.exports;
+
+      if(pkgExports) PACKAGE_JSON.exports = pkgExports;
+
       !DEBUG &&
         fs.writeFileSync(path.join(PATH_TO_PACKAGE, "package.json"), JSON.stringify(PACKAGE_JSON, null, 2));
     }

--- a/index.js
+++ b/index.js
@@ -229,7 +229,15 @@ ${PACKAGE_JSON.version}
     function createGitCommit() {
       log("🤖 - Create git commit");
 
-      const gitCommand = `git add . && git commit -m "Commiting ${PACKAGE_JSON.version} - ${YEAR}-${MONTH}-${DAY}"`;
+      const gitStatusCommand = `git status --porcelain`;
+      const hasChanges = execSync(gitStatusCommand).toString().trim().length > 0;
+
+      if (!hasChanges) {
+        log("🤖 - No changes to commit");
+        return;
+      }
+
+      const gitCommand = `git add . && git commit -m "Committing ${PACKAGE_JSON.version} - ${YEAR}-${MONTH}-${DAY}"`;
 
       DEBUG &&
         log(gitCommand);
@@ -278,7 +286,7 @@ ${PACKAGE_JSON.version}
 
       const pkgExports = PACKAGE_JSON_POST_BUILD_PARSED?.exports;
 
-      if(pkgExports) PACKAGE_JSON.exports = pkgExports;
+      if (pkgExports) PACKAGE_JSON.exports = pkgExports;
 
       !DEBUG &&
         fs.writeFileSync(path.join(PATH_TO_PACKAGE, "package.json"), JSON.stringify(PACKAGE_JSON, null, 2));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/bumper",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "bin": {
     "omariosouto-bumper": "./bin/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/bumper",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "bin": {
     "omariosouto-bumper": "./bin/cli.js"
   },


### PR DESCRIPTION
## Changelog

This pull request includes several changes to the `index.js` file to improve the handling of the `package.json` exports and streamline the commit process during the CI workflow. The most important changes include adding a function to reset the `package.json` exports, adjusting the order of operations to make a single commit, and ensuring the `package.json` exports are synced post-build.

### Improvements to handling `package.json` exports:

* Added `PACKAGE_JSON_ORIGINAL_EXPORTS` to store the original exports from `package.json`.
* Implemented the `resetPkgExports` function to reset the `package.json` exports to their original state.
* Modified the `syncPackageJSON` function to update the `package.json` exports with the post-build exports.

### Streamlining commit process:

* Adjusted the order of operations to include `resetPkgExports`, `createGitCommit`, and `pushToPR` to ensure a single commit is made instead of multiple commits.
